### PR TITLE
Feature/pi exclusives

### DIFF
--- a/ansible/roles/cluster/tasks/cluster_checks.yml
+++ b/ansible/roles/cluster/tasks/cluster_checks.yml
@@ -22,4 +22,4 @@
   run_once: true
   delegate_to: "{{ cluster_main_master }}"
   when:
-    - cluster_control_plane_endpoint | len < 1
+    - cluster_control_plane_endpoint | length < 1

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -13,6 +13,7 @@
 
 - name: raspberry pi config
   include_tasks: rpi_config.yml
+  when: ansible_architecture | regex_search('arm|aarch')
 
 - name: common tasks
   include_tasks: common.yml

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -81,6 +81,7 @@
   file:
     path: /boot/firmware/nobtcmd.txt
     state: touch
+  when: ansible_architecture | regex_search('arm|aarch')
 
 - name: enable required cgroup features
   lineinfile:
@@ -90,6 +91,7 @@
     regexp: '^(.*fixrtc)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   notify: reboot hosts
+  when: ansible_architecture | regex_search('arm|aarch')
 
 # Set /proc/sys/net/bridge/bridge-nf-call-iptables to 1 by running
 # sysctl net.bridge.bridge-nf-call-iptables=1 to pass bridged IPv4 traffic to iptables’ chains.


### PR DESCRIPTION
# Description

Running Raspberry Pis in your cluster is fantastic for smaller deployments. However, endlessly scaling horizontally may not be a great solution for some people (or they may not have enough Pis). Moving to a different size of nodes, such as running a full x86_64 architecture. In these mixed environment cases the playbook needs to be able to evaluate what the CPU architecture is and take actions accordingly. Eventually I imagine that the logical conclusion of what this PR starts will be conditionally importing tasks based on arch or distro, but for now this allows alternate archs (in my case x86_64) to excuse themselves from running tasks that are specifically for configuring a Pi. 

I am only able to test on my own hardware (duh), so this has only been tested on my inventory of:
3 RPi 4 4GB, masters
3 Dell R610s, nodes

Additionally, I have altered a conditional that wasn't working in the form of [this line](https://github.com/raspbernetes/k8s-cluster-installation/blob/779ff0cd925a1aa56e6272956638091cc48b2f5b/ansible/roles/cluster/tasks/cluster_checks.yml#L25). For some reason that filter was not agreeing with my version of Ansible (2.8.1). If this isn't a reasonable change, then I'm cool to drop that change.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [X] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

technically it addresses #10 but it's not really open

## Notes

This is mainly to start discussion. While it is functional (at least for my use case) I'm mostly curious to see what direction you all will want to head with it.
