### PR TITLE
Implementing fix for USB SSD issue

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -3,6 +3,8 @@
 #common_upgrade_packages: true
 #common_reboot_handler_enabled: true
 #common_timezone: UTC
+#common_usb_ssd_enabled: false
+#common_usb_ssd_device_id: ""
 #common_rpi_overclock: false
 #common_rpi_poe_hat: false
 #common_log2ram_version: v1.4

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -4,6 +4,9 @@ common_upgrade_packages: true # Set to false to not run package upgrades
 common_reboot_handler_enabled: true # Set to false to not reboot after changes
 common_timezone: UTC
 
+common_usb_ssd_enabled: false # Set to true when having issues with the USB SSD disconnecting, currently ArchLinux only
+common_usb_ssd_device_id: "" # Device ID output from 'lsusb', prefixed with 0x, e.g.: '174c:55aa' -> '0x174c:0x55aa'
+
 common_rpi_cmd_file: /boot/firmware/cmdline.txt # For kernel arguments
 common_rpi_config_file: /boot/firmware/syscfg.txt # For RPi configuration
 

--- a/ansible/roles/common/tasks/archlinux.yml
+++ b/ansible/roles/common/tasks/archlinux.yml
@@ -25,6 +25,16 @@
     line: '\1 cgroup_enable=memory cgroup_memory=1'
   notify: reboot hosts
 
+- name: disable uas driver on usb ssd
+  lineinfile:
+    path: '{{ common_rpi_cmd_file }}'
+    state: present
+    backrefs: true
+    regexp: '^(.*rw rootwait(?<!usb-storage.quirks={{ common_usb_ssd_device_id }}:u)) (console=.*)$'
+    line: '\1 usb-storage.quirks={{ common_usb_ssd_device_id }}:u \2'
+  when: common_usb_ssd_enabled
+  notify: reboot hosts
+
 - name: check for yay
   stat:
     path: /usr/bin/yay

--- a/ansible/roles/common/tasks/pre_checks.yml
+++ b/ansible/roles/common/tasks/pre_checks.yml
@@ -17,6 +17,25 @@
       - 'Type is: {{ common_timezone | type_debug }}'
       - "Value is: {{ common_timezone | default('undefined') }}"
 
+- name: 'validate variable : common_usb_ssd_enabled'
+  assert:
+    that:
+      - common_usb_ssd_enabled | type_debug == 'bool'
+    fail_msg:
+      - "Variable 'common_usb_ssd_enabled' should be of type 'bool'"
+      - 'Type is: {{ common_usb_ssd_enabled | type_debug }}'
+      - "Value is: {{ common_usb_ssd_enabled | default('undefined') }}"
+
+- name: 'validate variable : common_usb_ssd_device_id'
+  assert:
+    that:
+      - common_usb_ssd_device_id | type_debug == 'AnsibleUnicode'
+    fail_msg:
+      - "Variable 'common_usb_ssd_device_id' should be of type AnsibleUnicode (string)"
+      - 'Type is: {{ common_usb_ssd_device_id | type_debug }}'
+      - "Value is: {{ common_usb_ssd_device_id | default('undefined') }}"
+
+
 - name: 'validate variable : common_rpi_cmd_file'
   assert:
     that:


### PR DESCRIPTION
Signed-off-by: Rob Reus <rob@devrobs.nl>

# Description

I had issues where my USB SSDs would get disconnected, rendering the system down. This fix forces the kernel to use the `usb-storage` driver instead of `uas`.

## Type Of Change

- [ ] Docs
- [ ] Installation
- [X] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)


## Notes

