### PR TITLE
Making etcd election-timeout and heartbeat-interval configurable

### DIFF
--- a/ansible/group_vars/masters.yml
+++ b/ansible/group_vars/masters.yml
@@ -15,6 +15,8 @@
 #cluster_audit_log_maxbackup: 10
 #cluster_audit_log_maxsize: 100
 #cluster_pod_subnet: ""
+#cluster_etcd_heartbeat_interval: "100"
+#cluster_etcd_election_timeout: "1000"
 
 # Role: cni
 #cni_plugin: calico

--- a/ansible/roles/cluster/defaults/main.yml
+++ b/ansible/roles/cluster/defaults/main.yml
@@ -10,3 +10,6 @@ cluster_audit_log_maxage: "30"
 cluster_audit_log_maxbackup: "10"
 cluster_audit_log_maxsize: "100"
 cluster_pod_subnet: ""
+# Default etcd values, change these if you experience "leader changed" issues when running on a SD card
+cluster_etcd_heartbeat_interval: 100
+cluster_etcd_election_timeout: 1000

--- a/ansible/roles/cluster/tasks/pre_checks.yml
+++ b/ansible/roles/cluster/tasks/pre_checks.yml
@@ -37,3 +37,21 @@
       - "Value is: {{ cluster_pod_subnet | default('undefined') }}"
   when:
     - cluster_pod_subnet != "" # noqa 602
+
+- name: 'validate variable : cluster_etcd_heartbeat_interval'
+  assert:
+    that:
+      - cluster_etcd_heartbeat_interval | type_debug == 'int'
+    fail_msg:
+      - "Variable 'cluster_etcd_heartbeat_interval' should be of type 'int'"
+      - 'Type is: {{ cluster_etcd_heartbeat_interval | type_debug }}'
+      - "Value is: {{ cluster_etcd_heartbeat_interval | default('undefined') }}"
+
+- name: 'validate variable : cluster_etcd_election_timeout'
+  assert:
+    that:
+      - cluster_etcd_election_timeout | type_debug == 'int'
+    fail_msg:
+      - "Variable 'cluster_etcd_election_timeout' should be of type 'int'"
+      - 'Type is: {{ cluster_etcd_election_timeout | type_debug }}'
+      - "Value is: {{ cluster_etcd_election_timeout | default('undefined') }}"

--- a/ansible/roles/cluster/templates/kubeadm-init.yml.j2
+++ b/ansible/roles/cluster/templates/kubeadm-init.yml.j2
@@ -46,6 +46,8 @@ etcd:
       client-cert-auth: "true"
       peer-client-cert-auth: "true"
       peer-auto-tls: "false"
+      heartbeat-interval: "{{ cluster_etcd_heartbeat_interval }}"
+      election-timeout: "{{ cluster_etcd_election_timeout }}"
 imageRepository: {{ cluster_image_repository }}
 networking:
   dnsDomain: cluster.local


### PR DESCRIPTION
Signed-off-by: Rob Reus <rob@devrobs.nl>

# Description

When running of an SD card, etcd will most likely have issues with IO where you'll see a lot of leader re-elections happen because the IO is too slow to respond. This will make the etcd settings to tweak this behaviour configurable.

## Type Of Change

- [ ] Docs
- [X] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

## Notes
