### PR TITLE
Fix CRI dependency on Kubernetes role; Update cloudflared role

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
   <a href="https://raspbernetes.github.io/docs/"><img src="https://raspbernetes.github.io/img/logo.svg" alt="Raspbernetes"></a>
 </h1>
 
+<a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fraspbernetes%2Fk8s-cluster-installation?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fraspbernetes%2Fk8s-cluster-installation.svg?type=shield"/></a>
+
+
 Installation instructions can be found here: https://raspbernetes.github.io/docs/installation
 
 ## Contributors
@@ -22,8 +25,6 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/raspbernetes#sponsor)]
 
 <a href="https://opencollective.com/raspbernetes/sponsor/0/website" target="_blank"><img src="https://opencollective.com/raspbernetes/sponsor/0/avatar.svg"></a> <a href="https://opencollective.com/raspbernetes/sponsor/1/website" target="_blank"><img src="https://opencollective.com/raspbernetes/sponsor/1/avatar.svg"></a>
-<a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fraspbernetes%2Fk8s-cluster-installation?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fraspbernetes%2Fk8s-cluster-installation.svg?type=shield"/></a>
-
 
 ## License
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -11,9 +11,9 @@
 #common_log2ram_size: 128M
 
 # Role: kubernetes
-#kubernetes_kubectl_version: 1.18.2-00
-#kubernetes_kubelet_version: 1.18.2-00
-#kubernetes_kubeadm_version: 1.18.2-00
+#kubernetes_kubectl_version: 1.18.6-00
+#kubernetes_kubelet_version: 1.18.6-00
+#kubernetes_kubeadm_version: 1.18.6-00
 
 # Role: cri
 #cri_plugin: docker

--- a/ansible/group_vars/masters.yml
+++ b/ansible/group_vars/masters.yml
@@ -25,6 +25,4 @@
 # Cloudflare options for exposing Kubernetes services via HTTPS/SSH
 #cloudflared_enabled: false
 #cloudflared_kube_api_server_dns: ''
-#cloudflared_ingress_sans: ''
-#cloudflared_ssh_port: 22
-#cloudflared_version: 2020.7.0
+#cloudflared_version: 2020.8.0

--- a/ansible/playbooks/common.yml
+++ b/ansible/playbooks/common.yml
@@ -6,6 +6,6 @@
       include_vars: "../family_vars/{{ ansible_os_family | lower }}.yml"
   roles:
     - common
-    - cri
     - kubernetes
+    - cri
 #    - networking

--- a/ansible/roles/cloudflared/defaults/main.yml
+++ b/ansible/roles/cloudflared/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
 cloudflared_enabled: false
 cloudflared_kube_api_server_dns: ''
-cloudflared_ingress_sans: ''
-cloudflared_ssh_port: 22
-cloudflared_version: 2020.7.0
+cloudflared_version: 2020.8.0

--- a/ansible/roles/cloudflared/tasks/install.yml
+++ b/ansible/roles/cloudflared/tasks/install.yml
@@ -45,5 +45,5 @@
     src: "{{ tempfolder.path }}/cloudflared"
     remote_src: yes
     dest: /usr/local/bin/cloudflared
-    mode: '0777'
+    mode: '0755'
   when: not cloudflared_binary.stat.exists

--- a/ansible/roles/cloudflared/tasks/install.yml
+++ b/ansible/roles/cloudflared/tasks/install.yml
@@ -45,4 +45,5 @@
     src: "{{ tempfolder.path }}/cloudflared"
     remote_src: yes
     dest: /usr/local/bin/cloudflared
+    mode: '0777'
   when: not cloudflared_binary.stat.exists

--- a/ansible/roles/cloudflared/tasks/pre_checks.yml
+++ b/ansible/roles/cloudflared/tasks/pre_checks.yml
@@ -20,30 +20,6 @@
   when:
     - cloudflared_enabled
 
-- name: 'validate variable : cloudflared_ingress_sans'
-  assert:
-    that:
-      - cloudflared_ingress_sans | type_debug == 'AnsibleUnicode'
-      - cloudflared_ingress_sans | length > 0
-    fail_msg:
-      - "Variable 'cloudflared_ingress_sans' should be of type AnsibleUnicode (string)"
-      - 'Type is: {{ cloudflared_ingress_sans | type_debug }}'
-      - "Value is: {{ cloudflared_ingress_sans | default('undefined') }}"
-  when:
-    - cloudflared_enabled
-
-- name: 'validate variable : cloudflared_ssh_port'
-  assert:
-    that:
-      - cloudflared_ingress_sans | type_debug == 'int'
-      - cloudflared_ingress_sans | length > 0
-    fail_msg:
-      - "Variable 'cloudflared_ssh_port' should be of type int"
-      - 'Type is: {{ cloudflared_ssh_port | type_debug }}'
-      - "Value is: {{ cloudflared_ssh_port | default('undefined') }}"
-  when:
-    - cloudflared_enabled
-
 - name: 'validate variable : cloudflared_version'
   assert:
     that:

--- a/ansible/roles/cloudflared/templates/config.yml.j2
+++ b/ansible/roles/cloudflared/templates/config.yml.j2
@@ -1,6 +1,5 @@
 hostname: '{{ cloudflared_kube_api_server_dns }}'
-url: 'tcp://{{ load_balancer_dns }}:{{ load_balancer_port }}'
-origin-server-name: '{{ cloudflared_ingress_sans }}'
-lb-pool: master-pool
+url: 'tcp://{{ keepalived_vip }}:8443'
+lb-pool: api-pool
 logfile: /var/log/cloudflared.log
 loglevel: info

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-kubernetes_kubelet_version: 1.18.2-00
-kubernetes_kubeadm_version: 1.18.2-00
-kubernetes_kubectl_version: 1.18.2-00
+kubernetes_kubelet_version: 1.18.6-00
+kubernetes_kubeadm_version: 1.18.6-00
+kubernetes_kubectl_version: 1.18.6-00


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Fixing the CRI from crashing when installing containerd on Ubuntu where it has a dependency on tasks in the Kubernetes role.

Also update cloudflared role to be designed for remote kubectl access using argo tunnel, therefore removing unused variables.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
