### PR TITLE
Added br_netfilter module load

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -2,3 +2,5 @@
 kubernetes_kubelet_version: 1.18.6-00
 kubernetes_kubeadm_version: 1.18.6-00
 kubernetes_kubectl_version: 1.18.6-00
+
+os_modules_load_list: /etc/modules

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -102,6 +102,14 @@
     name: br_netfilter
     state: present
 
+- name: persist br_netfilter load through reboots
+  lineinfile:
+    path: '{{ os_modules_load_list }}'
+    state: present
+    regex: '^br_netfilter'
+    line: 'br_netfilter'
+  notify: reboot hosts
+
 - name: Update bridged IPv4 traffic to iptables' chains
   sysctl:
     name: net.bridge.bridge-nf-call-iptables

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -97,6 +97,11 @@
 # sysctl net.bridge.bridge-nf-call-iptables=1 to pass bridged IPv4 traffic to iptables’ chains.
 # This is a requirement for some CNI plugins to work.
 # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
+- name: Load br_netfilter
+  modprobe:
+    name: br_netfilter
+    state: present
+
 - name: Update bridged IPv4 traffic to iptables' chains
   sysctl:
     name: net.bridge.bridge-nf-call-iptables


### PR DESCRIPTION
Load module br_netfilter before updating briged traffic

# Description
Following the installation guide on a fresh install of 4 RPis with Ubuntu 20.04 I got the following error:

TASK [kubernetes : Update bridged IPv4 traffic to iptables' chains] ***********************************************************
Thursday 20 August 2020  16:25:44 +0100 (0:00:01.043)       0:04:12.602 ******* 
fatal: [k8s-master-01]: FAILED! => changed=false 
  msg: |-
    **Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory**

After investigating the cause it seems that the br_netfilter is not loaded by default in the OS.
https://gist.github.com/iamcryptoki/ed6925ce95f047673e7709f23e0b9939

Edited the ansible script for kubernetes tasks to load that module. 

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [X] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience
