### PR TITLE
unhold packages if the cluster is nuked

### DIFF
--- a/ansible/playbooks/nuke.yml
+++ b/ansible/playbooks/nuke.yml
@@ -39,3 +39,12 @@
       file:
         path: /etc/cni/net.d
         state: absent
+
+    - name: remove apt-mark hold
+      dpkg_selections:
+        name: "{{ item }}"
+        selection: purge
+      loop:
+        - 'kubectl'
+        - 'kubelet'
+        - 'kubeadm'

--- a/ansible/playbooks/nuke.yml
+++ b/ansible/playbooks/nuke.yml
@@ -48,3 +48,4 @@
         - 'kubectl'
         - 'kubelet'
         - 'kubeadm'
+      when: ansible_os_family | lower == 'debian'


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

When a cluster is nuked it should unhold packages that were previously marked on hold. This also allows for complete rebuilds to be able to do an upgrade without issue.

```
kubelet
kubeadm
kubectl
```

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
