### PR TITLE
Bugfix/pkg hold

### DIFF
--- a/ansible/playbooks/nuke.yml
+++ b/ansible/playbooks/nuke.yml
@@ -49,3 +49,11 @@
         - 'kubelet'
         - 'kubeadm'
       when: ansible_os_family | lower == 'debian'
+
+    # Issue caused when OpenEBS hasn't grafefully performed garbage collection when cluster is nuked.
+    # This ensures the directory is not left in a corrupted state:
+    # https://kubernetes.slack.com/archives/CUAKPFU78/p1597059291191700?thread_ts=1597053760.188200&cid=CUAKPFU78
+    - name: remove openebs directory
+      file:
+        path: /etc/openebs
+        state: absent

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -24,7 +24,7 @@
       - kubeadm={{ kubernetes_kubeadm_version }}
       - kubectl={{ kubernetes_kubectl_version }}
     state: present
-    force: true
+    force: yes
     update_cache: yes
   register: apt_install_kube
   retries: 5

--- a/ansible/roles/kubernetes/tasks/debian.yml
+++ b/ansible/roles/kubernetes/tasks/debian.yml
@@ -24,6 +24,7 @@
       - kubeadm={{ kubernetes_kubeadm_version }}
       - kubectl={{ kubernetes_kubectl_version }}
     state: present
+    force: true
     update_cache: yes
   register: apt_install_kube
   retries: 5


### PR DESCRIPTION
# Description

The nuke role now will mark the packages to be unheld, this means a subsequent execution to set up the cluster these packages will be upgraded automatically during the upgrade steps when re-installing it will complain about downgrades which are intended as the version is explicit and therefore this downgrade should be possible.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
