### PR TITLE
fix pods cleanup, add check for containerd socket before uninstalling

### DIFF
--- a/ansible/roles/cri/tasks/uninstall.yml
+++ b/ansible/roles/cri/tasks/uninstall.yml
@@ -6,6 +6,11 @@
     path: '/usr/local/bin/crictl'
   register: crictl
 
+- name: 'uninstall | check if containerd is running'
+  ansible.builtin.stat:
+    path: '/run/containerd/containerd.sock'
+  register: containerd_sock
+
 - name: 'uninstall | stop all cri containers'
   ansible.builtin.shell: |
     set -o pipefail && /usr/local/bin/crictl ps -q | xargs -r /usr/local/bin/crictl -t 10s stop
@@ -17,6 +22,7 @@
   delay: 5
   when:
   - crictl.stat.exists
+  - containerd_sock.stat.exists
   - cri_plugin == 'containerd'
   ignore_errors: true
 
@@ -29,11 +35,12 @@
   delay: 5
   when:
   - crictl.stat.exists
+  - containerd_sock.stat.exists
   - cri_plugin == 'containerd'
 
 - name: 'uninstall | stop all containerd pods'
   ansible.builtin.shell: |
-    set -o pipefail && /usr/local/bin/crictl ps -q | xargs -r /usr/local/bin/crictl -t 10s stopp
+    set -o pipefail && /usr/local/bin/crictl pods -q | xargs -r /usr/local/bin/crictl -t 10s stopp
   args:
     executable: '/bin/bash'
   register: stop_all_pods
@@ -42,6 +49,7 @@
   delay: 5
   when:
   - crictl.stat.exists
+  - containerd_sock.stat.exists
   - cri_plugin == 'containerd'
   ignore_errors: true
 
@@ -54,6 +62,7 @@
   delay: 5
   when:
   - crictl.stat.exists
+  - containerd_sock.stat.exists
   - cri_plugin == 'containerd'
 
 # Uninstall ContainerD from Ubuntu/Debian platforms
@@ -64,6 +73,7 @@
       name: 'containerd'
       state: stopped
       enabled: false
+    when: containerd_sock.stat.exists
   - name: 'uninstall | uninstall containerd package'
     ansible.builtin.package:
       name: containerd.io
@@ -76,11 +86,15 @@
     ansible.builtin.file:
       path: '{{ cri_containerd_config_dir }}'
       state: 'absent'
-  when: ansible_os_family|lower == 'debian'
+  when:
+  - ansible_os_family|lower == 'debian'
+  - cri_plugin == 'containerd'
 
 # Archlinux uninstallation of containerd package
 - name: 'uninstall | remove containerd package'
   pacman:
     name: 'containerd'
     state: 'absent'
-  when: ansible_os_family|lower == 'archlinux'
+  when:
+  - ansible_os_family|lower == 'archlinux'
+  - cri_plugin == 'containerd'


### PR DESCRIPTION
Signed-off-by: Nick M <4718+rkage@users.noreply.github.com>

- fix to address some errors when role is run multiple times and containerd is already disabled/uninstalled or never was installed in the first place.
- fix to the stop pods task, check for running pods get those id's rather than the container id's