### PR TITLE
increase the timeout to stop containers and pods from 10s to 60s

### DIFF
--- a/ansible/roles/cri/tasks/uninstall.yml
+++ b/ansible/roles/cri/tasks/uninstall.yml
@@ -13,7 +13,7 @@
 
 - name: 'uninstall | stop all cri containers'
   ansible.builtin.shell: |
-    set -o pipefail && /usr/local/bin/crictl ps -q | xargs -r /usr/local/bin/crictl -t 10s stop
+    set -o pipefail && /usr/local/bin/crictl ps -q | xargs -r /usr/local/bin/crictl -t 60s stop
   args:
     executable: '/bin/bash'
   register: stop_all_containers
@@ -40,7 +40,7 @@
 
 - name: 'uninstall | stop all containerd pods'
   ansible.builtin.shell: |
-    set -o pipefail && /usr/local/bin/crictl pods -q | xargs -r /usr/local/bin/crictl -t 10s stopp
+    set -o pipefail && /usr/local/bin/crictl pods -q | xargs -r /usr/local/bin/crictl -t 60s stopp
   args:
     executable: '/bin/bash'
   register: stop_all_pods


### PR DESCRIPTION
Signed-off-by: Nick M <4718+rkage@users.noreply.github.com>

# Description

This increases the timeout on remove pods and containers tasks when removing containerd, timeout increased from 10s to 60s

rationale, some containers take awhile to startup/sandbox and containerd prevents killing them. time is needed to forcefully stop them