### PR TITLE
Drop FQCN from command module

### DIFF
--- a/ansible/playbooks/nuke.yml
+++ b/ansible/playbooks/nuke.yml
@@ -87,7 +87,7 @@
       ignore_errors: true
 
     - name: 'uninstall | remove all cri containers'
-      ansible.builtin.command: |
+      command: |
         /usr/local/bin/crictl rm -a -f
       register: remove_all_containers
       retries: 5
@@ -115,7 +115,7 @@
       ignore_errors: true
 
     - name: 'uninstall | remove all containerd pods'
-      ansible.builtin.command: |
+      command: |
         /usr/local/bin/crictl rmp -a -f
       register: remove_all_pods
       retries: 5

--- a/ansible/roles/cri/tasks/containerd.yml
+++ b/ansible/roles/cri/tasks/containerd.yml
@@ -41,7 +41,7 @@
     group: 'root'
 
 - name: 'containerd | generate default configuration file'
-  ansible.builtin.command: |
+  command: |
     containerd config default
   register: containerd_default_config_file
   changed_when: false

--- a/ansible/roles/cri/tasks/uninstall.yml
+++ b/ansible/roles/cri/tasks/uninstall.yml
@@ -27,7 +27,7 @@
   ignore_errors: true
 
 - name: 'uninstall | remove all cri containers'
-  ansible.builtin.command: |
+  command: |
     /usr/local/bin/crictl rm -a -f
   register: remove_all_containers
   retries: 5
@@ -54,7 +54,7 @@
   ignore_errors: true
 
 - name: 'uninstall | remove all containerd pods'
-  ansible.builtin.command: |
+  command: |
     /usr/local/bin/crictl rmp -a -f
   register: remove_all_pods
   retries: 5


### PR DESCRIPTION
# Description

There is a present bug below ansible 2.10.x preventing users from using the command module when it's defined with a FQCN. Since 2.10.x is quite the bleeding edge at the moment and Fedora is still shipping with 2.9.x we should revert to just using `command` until 2.10.x becomes more widely available or a fix becomes backported 

Relevant PR: https://github.com/ansible/ansible/pull/72958

## Checklist

- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

https://discord.com/channels/673534664354430999/673534665155674114/805530302713167912

