### PR TITLE
add ipvsadm to required packages

### DIFF
--- a/ansible/family_vars/archlinux.yml
+++ b/ansible/family_vars/archlinux.yml
@@ -16,6 +16,7 @@ common_packages:
   - vim
   - curl
   - net-tools
+  - ipvsadm
   - sysstat
   - python-pyopenssl # Needed for ansible 'openssl_certificate_info' module
   - python-pip # Needed for ansible openshift module

--- a/ansible/family_vars/debian.yml
+++ b/ansible/family_vars/debian.yml
@@ -9,6 +9,7 @@ common_packages:
   - git
   - vim
   - curl
+  - ipvsadm
   - net-tools
   - python3-openssl # Needed for ansible 'openssl_certificate_info' module
   - python3-pip


### PR DESCRIPTION
Signed-off-by: Nick M <4718+rkage@users.noreply.github.com>

# Description

Add `ipvsadm` as a required package; the nuke process has been updated to clear ipvs tables.