### PR TITLE
Fix/keepalived configuration

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -21,9 +21,31 @@
 # kubernetes_kubeadm_version: 1.20.2-00
 
 ####
+# Role - keepalived
+####
+# keepalived_vip: ""
+# keepalived_interface: "{{ ansible_default_ipv4['interface'] }}"
+
+####
 # Role - cri
 ####
 # cri_plugin: containerd
+# cri_containerd_version: '1.4.3'
+
+####
+# Role - cni
+####
+# cni_plugin: 'calico'
+# cni_bgp_peer_address: 192.168.0.1
+# cni_bgp_peer_asn: 64512
+# cni_cilium_helm_version: 1.9.3
+# cni_cilium_image_version: v1.9.3
+# cni_cilium_hubble_enabled: false
+# cni_cilium_enovy_proxy_image_version: v1.16.2
+# cni_cilium_bpf_hostrouting: "true"
+# cni_cilium_bpf_tproxy: "false"
+# cni_cilium_bpf_masquerade: "true"
+# cni_cilium_endpoint_routes: "false"
 
 ####
 # Role: Storage
@@ -34,3 +56,11 @@
 # Role: docker_cache
 ####
 # docker_cache_enable: false
+
+####
+# Role - cloudflared
+####
+# Cloudflare options for exposing Kubernetes services via HTTPS/SSH
+# cloudflared_enabled: false
+# cloudflared_kube_api_server_dns: ''
+# cloudflared_version: 2020.11.11

--- a/ansible/group_vars/cluster.yml
+++ b/ansible/group_vars/cluster.yml
@@ -1,5 +1,10 @@
 ---
 
+cluster_name: kubernetes
+cluster_extra_sans:
+- '{{ keepalived_vip }}'
+cluster_control_plane_endpoint: '{{ keepalived_vip }}:8443'
+
 # Specify the Kubernetes version, current release is v1.20.0
 cluster_kubernetes_version: 'v1.20.2'
 
@@ -42,48 +47,3 @@ cluster_etcd_snapshot_count: 5000
 
 # Kube Proxy mode either ipvs or iptables; Default iptables
 cluster_kube_proxy_mode: 'ipvs'
-
-
-####
-# Role - cri
-####
-cri_plugin: 'containerd'
-cri_containerd_version: '1.4.3'
-
-## Old variables
-####
-# Role - keepalived
-####
-keepalived_vip: 192.168.91.240
-keepalived_interface: "{{ ansible_default_ipv4['interface'] }}"
-
-####
-# Role - cluster
-####
-cluster_name: kubernetes
-cluster_extra_sans:
-- '{{ keepalived_vip }}'
-cluster_control_plane_endpoint: '{{ keepalived_vip }}:8443'
-
-####
-# Role - cni
-####
-cni_plugin: 'calico'
-# cni_bgp_peer_address: 192.168.0.1
-# cni_bgp_peer_asn: 64512
-# cni_cilium_helm_version: 1.9.3
-# cni_cilium_image_version: v1.9.3
-# cni_cilium_hubble_enabled: false
-# cni_cilium_enovy_proxy_image_version: v1.16.2
-# cni_cilium_bpf_hostrouting: "true"
-# cni_cilium_bpf_tproxy: "false"
-# cni_cilium_bpf_masquerade: "true"
-# cni_cilium_endpoint_routes: "false"
-
-####
-# Role - cloudflared
-####
-# Cloudflare options for exposing Kubernetes services via HTTPS/SSH
-cloudflared_enabled: false
-# cloudflared_kube_api_server_dns: ''
-# cloudflared_version: 2020.11.11

--- a/ansible/roles/cluster/defaults/main/main.yml
+++ b/ansible/roles/cluster/defaults/main/main.yml
@@ -119,6 +119,6 @@ cluster_extra_sans:
 cluster_control_plane_endpoint: "" # defaults to '{{ keepalived_vip }}:8443' when left empty
 
 # Old Vars
-cluster_main_master: "{{ groups['masters'][0] }}"
+cluster_main_master: "{{ groups['controlplane'][0] }}"
 cluster_etcd_datadir: /var/lib/etcd
 cluster_image_repository: k8s.gcr.io

--- a/ansible/roles/cluster/tasks/join.yml
+++ b/ansible/roles/cluster/tasks/join.yml
@@ -2,7 +2,7 @@
 - name: 'join | upload certificates to API server'
   ansible.builtin.command: |
     kubeadm init phase upload-certs --certificate-key {{ kubeadm_certificate_key }} --skip-certificate-key-print --upload-certs
-  delegate_to: '{{ groups["masters"]|first }}'
+  delegate_to: '{{ groups["controlplane"]|first }}'
   run_once: true
   when: cluster_initialized is not defined
 
@@ -11,14 +11,14 @@
     kubeadm token create {{ kubeadm_join_token }}
     --certificate-key {{ kubeadm_certificate_key }}
     --ttl 10m
-  delegate_to: '{{ groups["masters"]|first }}'
+  delegate_to: '{{ groups["controlplane"]|first }}'
   run_once: true
   when: cluster_initialized is not defined
 
 - name: 'join | retrieve cluster ca certificate'
   ansible.builtin.openssl_certificate_info:
     path: /etc/kubernetes/pki/ca.crt
-  delegate_to: '{{ groups["masters"]|first }}'
+  delegate_to: '{{ groups["controlplane"]|first }}'
   register: cluster_ca_cert
   run_once: true
 
@@ -35,7 +35,7 @@
 
 - name: 'join | check/wait for cluster apiserver to be available'
   ansible.builtin.wait_for:
-    host: '{{ hostvars[groups["masters"]|first]["ansible_default_ipv4"]["address"] }}'
+    host: '{{ hostvars[groups["controlplane"]|first]["ansible_default_ipv4"]["address"] }}'
     port: '{{ cluster_apiserver_bind_port }}'
     timeout: 180
 

--- a/ansible/roles/cluster/tasks/main.yml
+++ b/ansible/roles/cluster/tasks/main.yml
@@ -20,7 +20,7 @@
   ansible.builtin.set_fact:
     cluster_control_plane_endpoint: '{{ keepalived_vip }}:8443'
   run_once: true
-  delegate_to: '{{ groups["masters"]|first }}'
+  delegate_to: '{{ groups["controlplane"]|first }}'
   when:
   - cluster_control_plane_endpoint | length < 1
 
@@ -48,14 +48,14 @@
 - name: 'pre-flight | generate certificate-key used to encrypt the certificates'
   ansible.builtin.command: |
     {{ kubeadm_certs_command }} certs certificate-key
-  delegate_to: '{{ groups["masters"]|first }}'
+  delegate_to: '{{ groups["controlplane"]|first }}'
   run_once: true
   register: generated_certificate_key
 
 - name: 'pre-flight | generate randomized token'
   ansible.builtin.command: |
     kubeadm token generate
-  delegate_to: '{{ groups["masters"]|first }}'
+  delegate_to: '{{ groups["controlplane"]|first }}'
   run_once: true
   register: generated_token
 
@@ -68,11 +68,11 @@
 - name: 'initialize | perform cluster initialization on primary control node'
   include_tasks: 'initialize.yml'
   when:
-  - inventory_hostname == groups["masters"]|first
+  - inventory_hostname == groups["controlplane"]|first
   - not kubelet_config.stat.exists
 
 - name: 'join | perform cluster join on remaining cluster nodes'
   include_tasks: 'join.yml'
   when:
-  - inventory_hostname != groups["masters"]|first
+  - inventory_hostname != groups["controlplane"]|first
   - not kubelet_config.stat.exists

--- a/ansible/roles/cluster/templates/kubeadm-config.yaml.j2
+++ b/ansible/roles/cluster/templates/kubeadm-config.yaml.j2
@@ -15,7 +15,7 @@ localAPIEndpoint:
 certificateKey: {{ kubeadm_certificate_key }}
 {% endif %}
 nodeRegistration:
-  {% if inventory_hostname in groups['masters'] and inventory_hostname not in groups['workers'] %}
+  {% if inventory_hostname in groups['controlplane'] and inventory_hostname not in groups['nodes'] %}
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master

--- a/ansible/roles/cluster/templates/kubeadm-join.yaml.j2
+++ b/ansible/roles/cluster/templates/kubeadm-join.yaml.j2
@@ -15,7 +15,7 @@ discovery:
     unsafeSkipCAVerification: true
     {% endif %}
   timeout: 5m0s
-{% if inventory_hostname in groups['masters'] %}
+{% if inventory_hostname in groups['controlplane'] %}
 controlPlane:
   localAPIEndpoint:
     advertiseAddress: {{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}

--- a/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -1,8 +1,8 @@
 vrrp_instance VI_1 {
-    state {{ 'MASTER' if hostvars[groups['masters'][0]] else 'BACKUP' }}
+    state {{ 'MASTER' if inventory_hostname in groups['controlplane']|first else 'BACKUP' }}
     interface {{ keepalived_interface }}
     virtual_router_id 1
-    priority {{ '150' if hostvars[groups['masters'][0]] else '100' }}
+    priority {{ '150' if inventory_hostname in groups['controlplane']|first else '100' }}
     advert_int 1
     authentication {
         auth_type PASS


### PR DESCRIPTION
# Description

Previous role created a keepalived.conf file that identified all nodes as primary. Depending on the order in which keepalived was restarted would result in the VIP moving around unintentionally. This could cause problems with cluster init tasks where the VIP for the APIserver had no viable backend.

