### PR TITLE
fix keepalived config so proper master is identified

### DIFF
--- a/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -1,8 +1,8 @@
 vrrp_instance VI_1 {
-    state {{ 'MASTER' if hostvars[groups['masters'][0]] else 'BACKUP' }}
+    state {{ 'MASTER' if inventory_hostname in groups['controlplane']|first else 'BACKUP' }}
     interface {{ keepalived_interface }}
     virtual_router_id 1
-    priority {{ '150' if hostvars[groups['masters'][0]] else '100' }}
+    priority {{ '150' if inventory_hostname in groups['controlplane']|first else '100' }}
     advert_int 1
     authentication {
         auth_type PASS


### PR DESCRIPTION
Signed-off-by: Nick M <4718+rkage@users.noreply.github.com>

# Description

Current configuration does not properly assign MASTER/BACKUP options in the config file. This PR properly configures the primary and backup VIP nodes. One possible problem with the existing configuration is the situation where the API server is not started on what is advertised as the primary VIP. This fix should eliminate an unintended configuration.