### PR TITLE
Set hostname in common role

### DIFF
--- a/ansible/roles/common/tasks/common.yml
+++ b/ansible/roles/common/tasks/common.yml
@@ -40,3 +40,7 @@
 - name: enable ntp
   command: /usr/bin/timedatectl set-ntp true
   when: "'NTP=no' in timedatectl_result.stdout"
+
+- name: 'set hostname'
+  hostname:
+    name: "{{ inventory_hostname }}"


### PR DESCRIPTION
# Description

This will work for debian flavored distros though unsure about Arch
linux or other distros. A workaround is to use the command module and make this a 3 step process. Which loses impotence. For now we should keep it like this. 

See this issue for more information

https://github.com/ansible/ansible/issues/42726

This will help ensure pre-ansible configuration is ensured throughout the whole process. Hostnames are important with k8s.

## Checklist

- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [X] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [ ] All workflow validation and compliance checks are passing.
