### PR TITLE
Replace pip installation with APT for python-openshift

### DIFF
--- a/ansible/family_vars/archlinux.yml
+++ b/ansible/family_vars/archlinux.yml
@@ -19,6 +19,5 @@ common_packages:
   - ipvsadm
   - sysstat
   - python-pyopenssl # Needed for ansible 'openssl_certificate_info' module
-  - python-pip # Needed for ansible openshift module
 common_rpi_cmd_file: /boot/cmdline.txt
 common_rpi_config_file: /boot/config.txt

--- a/ansible/family_vars/debian.yml
+++ b/ansible/family_vars/debian.yml
@@ -12,4 +12,4 @@ common_packages:
   - ipvsadm
   - net-tools
   - python3-openssl # Needed for ansible 'openssl_certificate_info' module
-  - python3-pip
+  - python-openshift

--- a/ansible/roles/common/tasks/archlinux.yml
+++ b/ansible/roles/common/tasks/archlinux.yml
@@ -78,3 +78,11 @@
     state: absent
   when:
     - not yay.stat.exists
+
+- name: 'install openshift kubernetes module'
+  aur:
+    name:
+      - python-openshift
+    use: yay
+    state: present
+  become: false

--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -1,4 +1,15 @@
 ---
+
+- name: 'add apt key for openshift kubernetes module (1/2)'
+  ansible.builtin.apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: ADF016E51783213C8A8C831A1348C52605DB2FE6
+
+- name: 'add OBS repo for openshift kubernetes module (2/2)'
+  ansible.builtin.apt_repository:
+    repo: deb http://download.opensuse.org/repositories/home:/anthr76:/kubernetes/Ubuntu_20.04/ /
+    state: present
+
 - name: apt-get upgrade
   apt:
     upgrade: full
@@ -24,21 +35,6 @@
   register: apt_install_common
   retries: 5
   until: apt_install_common is success
-
-- name: 'add apt key for openshift kubernetes module (1/3)'
-  ansible.builtin.apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: ADF016E51783213C8A8C831A1348C52605DB2FE6
-
-- name: 'add OBS repo for openshift kubernetes module (2/3)'
-  ansible.builtin.apt_repository:
-    repo: deb http://download.opensuse.org/repositories/home:/anthr76:/kubernetes/Ubuntu_20.04/ /
-    state: present
-
-- name: 'install openshift kubernetes module (3/3)'
-  apt:
-    name: python-openshift
-    update_cache: yes
 
 - name: install and configure log2ram
   include_tasks: log2ram.yml

--- a/ansible/roles/common/tasks/debian.yml
+++ b/ansible/roles/common/tasks/debian.yml
@@ -25,10 +25,20 @@
   retries: 5
   until: apt_install_common is success
 
-- name: install common Kubernetes ansible module
-  pip:
-    name:
-      - openshift
+- name: 'add apt key for openshift kubernetes module (1/3)'
+  ansible.builtin.apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: ADF016E51783213C8A8C831A1348C52605DB2FE6
+
+- name: 'add OBS repo for openshift kubernetes module (2/3)'
+  ansible.builtin.apt_repository:
+    repo: deb http://download.opensuse.org/repositories/home:/anthr76:/kubernetes/Ubuntu_20.04/ /
+    state: present
+
+- name: 'install openshift kubernetes module (3/3)'
+  apt:
+    name: python-openshift
+    update_cache: yes
 
 - name: install and configure log2ram
   include_tasks: log2ram.yml


### PR DESCRIPTION
# Description

Let python-openshift be managed with APT instead of PIP. I'm maintaining a repo for various debian flavors but at the moment 20.04 is hardcoded. We'll remain to pull in from the AUR for arch linux.

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [ ] All workflow validation and compliance checks are passing.

## Notes

Resolves tech debt from https://github.com/raspbernetes/k8s-cluster-installation/pull/72