### PR TITLE
terraform-provider-libvirt aarch64 complete support on Ubuntu 20.10

### DIFF
--- a/infrastructure/libvirt/ubuntu/aarch64/README.md
+++ b/infrastructure/libvirt/ubuntu/aarch64/README.md
@@ -1,3 +1,0 @@
-# Note
-
-This is not yet supported on the latest released terraform-provider-libvirt, at least easily. Support will likely pickup in next release. (https://github.com/dmacvicar/terraform-provider-libvirt/pull/816)

--- a/infrastructure/libvirt/ubuntu/aarch64/aarch64_machine.xsl
+++ b/infrastructure/libvirt/ubuntu/aarch64/aarch64_machine.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output omit-xml-declaration="yes" indent="yes"/>
+
+    <!-- Copy nodes by default -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Change disk bus to SATA -->
+    <xsl:template match="/domain/devices/disk/target/@bus">
+        <xsl:attribute name="bus">
+            <xsl:value-of select="'virtio'"/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <xsl:param name="pReplacement" select="'cortex-a57'"/>
+    
+    <!-- Change CPU model to cortex-a57 -->
+    <xsl:template match="/domain/cpu[@mode='custom'][@match='exact'][@check='none']/model/@fallback">
+          <xsl:attribute name="fallback">
+              <xsl:value-of select="'allow'"/>
+          </xsl:attribute>
+          <xsl:value-of select="'cortext-a57'"/>
+    </xsl:template>
+    
+
+
+    <!-- Remove WWM: only ide and scsi disk support wwn -->
+    <xsl:template match="/domain/devices/disk/wwn" />
+
+</xsl:stylesheet>

--- a/infrastructure/libvirt/ubuntu/aarch64/aarch64_machine.xsl
+++ b/infrastructure/libvirt/ubuntu/aarch64/aarch64_machine.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output omit-xml-declaration="yes" indent="yes"/>
+<xsl:output omit-xml-declaration="yes" indent="yes"/>
 
     <!-- Copy nodes by default -->
     <xsl:template match="node()|@*">
@@ -17,18 +17,17 @@
         </xsl:attribute>
     </xsl:template>
 
-    <xsl:param name="pReplacement" select="'cortex-a57'"/>
-    
     <!-- Change CPU model to cortex-a57 -->
-    <xsl:template match="/domain/cpu[@mode='custom'][@match='exact'][@check='none']/model/@fallback">
-          <xsl:attribute name="fallback">
-              <xsl:value-of select="'allow'"/>
-          </xsl:attribute>
-          <xsl:value-of select="'cortext-a57'"/>
+    <xsl:template match="/domain/cpu">
+      <xsl:copy>
+        <xsl:apply-templates select="node()|@*"/>
+        <xsl:element name ="model">
+          <xsl:attribute name="fallback">allow</xsl:attribute>
+          <xsl:value-of select="'cortex-a57'"/>
+        </xsl:element>
+      </xsl:copy>
     </xsl:template>
     
-
-
     <!-- Remove WWM: only ide and scsi disk support wwn -->
     <xsl:template match="/domain/devices/disk/wwn" />
 

--- a/infrastructure/libvirt/ubuntu/aarch64/aarch64_machine.xsl
+++ b/infrastructure/libvirt/ubuntu/aarch64/aarch64_machine.xsl
@@ -10,10 +10,10 @@
         </xsl:copy>
     </xsl:template>
 
-    <!-- Change disk bus to SATA -->
-    <xsl:template match="/domain/devices/disk/target/@bus">
+    <!-- Change disk bus to virtio -->
+    <xsl:template match="/domain/devices/disk[@type='file']/target/@bus">
         <xsl:attribute name="bus">
-            <xsl:value-of select="'virtio'"/>
+            <xsl:value-of select="'sata'"/>
         </xsl:attribute>
     </xsl:template>
 
@@ -23,7 +23,7 @@
         <xsl:apply-templates select="node()|@*"/>
         <xsl:element name ="model">
           <xsl:attribute name="fallback">allow</xsl:attribute>
-          <xsl:value-of select="'cortex-a57'"/>
+          <xsl:value-of select="'cortex-a72'"/>
         </xsl:element>
       </xsl:copy>
     </xsl:template>

--- a/infrastructure/libvirt/ubuntu/aarch64/cloud_init.cfg
+++ b/infrastructure/libvirt/ubuntu/aarch64/cloud_init.cfg
@@ -28,10 +28,3 @@ users:
 growpart:
   mode: auto
   devices: ['/']
-network:
-  version: 2
-  ethernets:
-    ens3:
-      match: 
-        name: "enp*"
-      dhcp4: true

--- a/infrastructure/libvirt/ubuntu/aarch64/cloud_init.cfg
+++ b/infrastructure/libvirt/ubuntu/aarch64/cloud_init.cfg
@@ -13,6 +13,8 @@
 #
 # Note: Content strings here are truncated for example purposes.
 ssh_pwauth: True
+packages:
+  - qemu-guest-agent
 chpasswd:
   list: |
      ubuntu:terraform-libvirt-linux
@@ -21,3 +23,15 @@ users:
   - name: ubuntu
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf Unsafe Shared Key
+growpart:
+  mode: auto
+  devices: ['/']
+network:
+  version: 2
+  ethernets:
+    ens3:
+      match: 
+        name: "enp*"
+      dhcp4: true

--- a/infrastructure/libvirt/ubuntu/aarch64/network_config.cfg
+++ b/infrastructure/libvirt/ubuntu/aarch64/network_config.cfg
@@ -1,4 +1,6 @@
-version: 2
-ethernets:
-  ens3:
-    dhcp4: true
+  version: 2
+  ethernets:
+    enp3s0:
+      match: 
+        name: "enp*"
+      dhcp4: true

--- a/infrastructure/libvirt/ubuntu/aarch64/ubuntu-aarch64.tf
+++ b/infrastructure/libvirt/ubuntu/aarch64/ubuntu-aarch64.tf
@@ -126,7 +126,7 @@ resource "libvirt_domain" "node" {
     network_name   = "ubuntu-network"
     hostname       = format(var.hostname_format, count.index + 1)
     mac            = "52:54:00:00:00:a${count.index + 1}"
-    wait_for_lease = false
+    wait_for_lease = true
   }
 
 }

--- a/infrastructure/libvirt/ubuntu/aarch64/ubuntu-aarch64.tf
+++ b/infrastructure/libvirt/ubuntu/aarch64/ubuntu-aarch64.tf
@@ -84,13 +84,13 @@ resource "libvirt_volume" "ubuntu" {
 resource "libvirt_domain" "node" {
   count   = var.hosts
   name    = format(var.hostname_format, count.index + 1)
-  vcpu    = 4
+  vcpu    = 8
   arch    = "aarch64"
   machine = "virt"
   firmware = "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw"
   memory  = 4096
 
-  # cloudinit = libvirt_cloudinit_disk.commoninit.id
+  cloudinit = libvirt_cloudinit_disk.commoninit.id
 
   xml {
     xslt = file("aarch64_machine.xsl")
@@ -98,7 +98,6 @@ resource "libvirt_domain" "node" {
 
   disk {
     volume_id = element(libvirt_volume.ubuntu.*.id, count.index)
-    scsi = "true"
   }
 
   console {
@@ -120,7 +119,7 @@ resource "libvirt_domain" "node" {
   }
 
   video {
-    type = "virtio"
+    type = "ramfb"
   }
 
   network_interface {

--- a/infrastructure/libvirt/ubuntu/aarch64/ubuntu-aarch64.tf
+++ b/infrastructure/libvirt/ubuntu/aarch64/ubuntu-aarch64.tf
@@ -96,10 +96,6 @@ resource "libvirt_domain" "node" {
     xslt = file("aarch64_machine.xsl")
   }
 
-  cpu = {
-    mode = "custom"
-  }
-
   disk {
     volume_id = element(libvirt_volume.ubuntu.*.id, count.index)
     scsi = "true"

--- a/infrastructure/libvirt/ubuntu/x86-64/cloud_init.cfg
+++ b/infrastructure/libvirt/ubuntu/x86-64/cloud_init.cfg
@@ -13,6 +13,8 @@
 #
 # Note: Content strings here are truncated for example purposes.
 ssh_pwauth: True
+packages:
+  - qemu-guest-agent
 chpasswd:
   list: |
      ubuntu:terraform-libvirt-linux

--- a/infrastructure/libvirt/ubuntu/x86-64/ubuntu-x86_64.tf
+++ b/infrastructure/libvirt/ubuntu/x86-64/ubuntu-x86_64.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.2"
+      version = "0.6.3"
     }
   }
 }


### PR DESCRIPTION
# Description

Further testing with the terraform-provider-libvirt provider

## Checklist

- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [X] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Made changes to the terraform-libvirt-provider to further test newer Ubuntu versions. Also got aarch64 Ubuntu's vm in a state where they work. You cannot yet use apply twice on the aarch64 vm, but I will look to iterate on that later (due to the cloud init XSLT).  aarch64 emulates cortex-a57 (Pi CPU)