### PR TITLE
Fixes for ansible-lint errors and warnings

### DIFF
--- a/ansible/playbooks/nuke.yml
+++ b/ansible/playbooks/nuke.yml
@@ -37,7 +37,8 @@
       loop:
         - kubelet.service.d/override.conf
         - kubelet.service.d/12-after-docker.conf
-      register: removed_services
+      notify:
+        - reload systemd
 
     - name: 'remove cluster default environtment files'
       ansible.builtin.file:
@@ -46,11 +47,6 @@
       loop:
         - kubelet
       register: removed_defaults
-
-    - name: 'reload systemd'
-      ansible.builtin.systemd:
-        daemon_reload: true
-      when: removed_services.changed
 
     - name: 'ensure calico link-netns devices have been removed'
       ansible.builtin.shell: |
@@ -202,3 +198,7 @@
       reboot:
         msg: 'hosts are being rebooted'
         reboot_timeout: '{{ reboot_timeout | default(600) }}'
+  handlers:
+    - name: 'reload systemd'
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/ansible/roles/cluster/tasks/pre_checks.yml
+++ b/ansible/roles/cluster/tasks/pre_checks.yml
@@ -36,7 +36,7 @@
       - 'Type is: {{ cluster_pod_subnet | type_debug }}'
       - "Value is: {{ cluster_pod_subnet | default('undefined') }}"
   when:
-    - cluster_pod_subnet != "" # noqa 602
+    - cluster_pod_subnet
 
 - name: 'validate variable : cluster_etcd_heartbeat_interval'
   ansible.builtin.assert:

--- a/ansible/roles/cni/meta/main.yml
+++ b/ansible/roles/cni/meta/main.yml
@@ -1,4 +1,13 @@
 ---
+galaxy_info:
+  author: raspbernetes
+  description: Enables Cilium CNI
+  license: Apache
+  min_ansible_version: 3.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
 collections:
   - kubernetes.core
   - ansible.posix

--- a/ansible/roles/docker_cache/tasks/registry.yml
+++ b/ansible/roles/docker_cache/tasks/registry.yml
@@ -3,6 +3,7 @@
   file:
     path: "/opt/compose/registry"
     state: directory
+    mode: 0755
 
 - name: Show registry compose file
   debug:
@@ -18,6 +19,7 @@
   file:
     path: "/opt/compose/registry/certs"
     state: directory
+    mode: 0755
   when: not cache_traefik_enable and cache_tls_enable
 
 - name: Copy over TLS cert and key
@@ -32,12 +34,14 @@
   template:
     src: registry-compose.yml.j2
     dest: "/opt/compose/registry/docker-compose.yml"
+    mode: preserve
   notify: registry up
 
 - name: Template registry config file
   template:
     src: registry.yml.j2
     dest: "/opt/compose/registry/config.yml"
+    mode: preserve
   notify: restart registry
 
 - name: flush handlers

--- a/ansible/roles/docker_cache/tasks/traefik.yml
+++ b/ansible/roles/docker_cache/tasks/traefik.yml
@@ -3,6 +3,7 @@
   file:
     path: "/opt/compose/traefik/{{ item }}"
     state: directory
+    mode: 0755
   loop:
     - "config"
     - "certs"
@@ -21,12 +22,14 @@
   template:
     src: traefik-compose.yml.j2
     dest: "/opt/compose/traefik/docker-compose.yml"
+    mode: preserve
   notify: traefik up
 
 - name: template traefik config file
   template:
     src: traefik.yml.j2
     dest: "/opt/compose/traefik/traefik.yml"
+    mode: preserve
   notify: restart traefik
 
 - name: Ensure log file exists
@@ -34,6 +37,7 @@
     content: ""
     dest: "/opt/compose/traefik/log"
     force: false
+    mode: preserve
 
 - name: flush handlers
   meta: flush_handlers


### PR DESCRIPTION
# Description

Resolved all warnings and errors from ansible-lint: [E503: no-handler], [E601: literal-compare], [E701: meta-no-info] and [E208: risky-file-permissions].

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): n/a

## Notes

I tried to make the changes as minimal as possible to avoid changing behavior, though I have not tested this changes to validate that they will work as expected.
