### PR TITLE
Changed inventory path to the ini filename.

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 roles_path = ./roles
-inventory = ./inventory
+inventory = ./inventory.ini
 library = ./library
 host_key_checking = False
 forks = 5


### PR DESCRIPTION
# Description

Please provide a description for what this PR is for.
ansible-playbook was failing on inventory until I updated the value to the full filename

## Checklist

- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] All commits contain a well written commit description including a title, description and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [ ] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.

Resolves the following error when running the ansible-playbook command (Ansible 2.9.6):
```
[WARNING]: Unable to parse /home/pi/src/k8s-cluster-installation/ansible/inventory as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'
```
